### PR TITLE
Add generate-only option

### DIFF
--- a/daml/Cucumber.daml
+++ b/daml/Cucumber.daml
@@ -16,7 +16,6 @@ module Cucumber
 
 import DA.Action
 import DA.Action.State.Class
-import DA.Exception
 import DA.Set
 import Daml.Script
 import LiftScript
@@ -43,22 +42,6 @@ data StepResult = StepResult
     ident : Text
     success : Bool
 
-tryCatch
-  : Script a
-  -> Script (Either Text a)
-tryCatch f = do
-  try
-    Right <$> f
-  catch
-    e@(GeneralError msg) -> do
-      pure $ Left msg
-    e@(PreconditionFailed msg) -> do
-      pure $ Left msg
-    e@(AssertionFailed msg) -> do
-      pure $ Left msg
-    e@(ArithmeticError msg) -> do
-      pure $ Left msg
-
 data Context = Context
   { currentScenario : Optional Text
   , currentStep : Optional StepKey
@@ -78,7 +61,7 @@ instance LiftScript Cucumber where
 startingContext: Context
 startingContext = Context None None mempty mempty mempty
 
-runCucumber: Cucumber a -> Script (a, Context)
+runCucumber : Cucumber a -> Script (a, Context)
 runCucumber testAction =
   runState startingContext action
   where
@@ -88,12 +71,9 @@ runCucumber testAction =
       tryRecordScenario
       pure result
 
-gets : (Applicative m, ActionState s m) => (s -> a) -> m a
-gets f = f <$> get
-
 report : Message -> Cucumber ()
 report msg =
-  modify $ \c -> c{ results = c.results <> [msg] }
+  modify $ \c -> c { results = c.results <> [msg] }
 
 tryRecordScenario : Cucumber ()
 tryRecordScenario = do
@@ -128,7 +108,6 @@ scenario' : Text -> Cucumber ()
 scenario' name = do
   tryRecordStep
   tryRecordScenario
-
   -- 'Push' on the current step
   modify (\c -> c { currentScenario = Some name })
 

--- a/daml/StateT.daml
+++ b/daml/StateT.daml
@@ -43,5 +43,8 @@ instance Action m => ActionState s (StateT s m) where
   put s = state $ \ _ -> ((), s)
   modify f = state $ \ s -> ((), f s)
 
+gets : (Applicative m, ActionState s m) => (s -> a) -> m a
+gets f = f <$> get
+
 runState: s -> StateT s m a -> m (a, s)
 runState s (StateT f) = f s

--- a/hs/daml-cucumber.cabal
+++ b/hs/daml-cucumber.cabal
@@ -37,7 +37,7 @@ library
     , casing                >=0.1.4   && <0.2
     , containers            >=0.6.5   && <0.7
     , directory             >=1.3.6   && <1.4
-    , extra                 >=1.7.10  && <1.8
+    , directory-contents    >=0.2     && <0.3
     , filepath              >=1.4.2   && <1.5
     , mtl                   >=2.2.2   && <2.3
     , neat-interpolation    >=0.4     && <0.5
@@ -57,6 +57,7 @@ library
     DeriveGeneric
     FlexibleContexts
     GeneralizedNewtypeDeriving
+    ImportQualifiedPost
     LambdaCase
     OverloadedStrings
     QuasiQuotes

--- a/hs/daml-cucumber.cabal
+++ b/hs/daml-cucumber.cabal
@@ -41,7 +41,6 @@ library
     , filepath              >=1.4.2   && <1.5
     , mtl                   >=2.2.2   && <2.3
     , neat-interpolation    >=0.4     && <0.5
-    , optparse-applicative  >=0.16.1  && <0.17
     , parsec                >=3.1.14  && <3.2
     , process               >=1.6.13  && <1.7
     , reflex                >=0.9.2   && <0.10
@@ -72,9 +71,7 @@ executable daml-cucumber
     , aeson
     , base
     , daml-cucumber
-    , optparse-applicative
-    , temporary
-    , text
+    , optparse-applicative  >=0.16.1  && <0.17
 
   ghc-options:      -O -threaded
   hs-source-dirs:   src-exe

--- a/hs/default.nix
+++ b/hs/default.nix
@@ -19,6 +19,7 @@ let
       which = haskellLib.doJailbreak super.which;
       reflex = self.callCabal2nix "reflex" (pkgs.hackGet ./dep/reflex) {};
       neat-interpolation = haskellLib.doJailbreak super.neat-interpolation;
+      coquina = haskellLib.markUnbroken (haskellLib.doJailbreak super.coquina);
       daml-cucumber = haskellLib.overrideCabal
         (self.callCabal2nix "daml-cucumber" src {})
         (drv: {

--- a/hs/src-exe/Main.hs
+++ b/hs/src-exe/Main.hs
@@ -8,6 +8,7 @@ data Opts = Opts
   , _opts_featureFile :: Maybe FilePath
   , _opts_damlSourceDir :: FilePath
   , _opts_allowMissing :: Bool
+  , _opts_generateOnly :: Bool
   }
 
 opts :: Parser Opts
@@ -27,6 +28,9 @@ opts = Opts
   <*> flag False True
       ( long "allow-missing"
       <> help "Don't fail if steps are missing" )
+  <*> flag False True
+      ( long "generate-only"
+      <> help "Generate daml test script but don't run the tests" )
 
 main :: IO ()
 main = do
@@ -40,3 +44,4 @@ main = do
     (_opts_featureFile options)
     (_opts_damlSourceDir options)
     (_opts_allowMissing options)
+    (_opts_generateOnly options)

--- a/hs/src-exe/Main.hs
+++ b/hs/src-exe/Main.hs
@@ -1,15 +1,13 @@
 module Main where
 
-import Control.Concurrent
-import Control.Monad
 import Daml.Cucumber
-import Daml.Cucumber.Types
-import Daml.Cucumber.LSP
-import qualified Data.Text as T
 import Options.Applicative
-import System.Exit
-import System.IO
-import System.IO.Temp
+
+data Opts = Opts
+  { _opts_directory :: FilePath
+  , _opts_featureFile :: Maybe FilePath
+  , _opts_damlSourceDir :: FilePath
+  }
 
 opts :: Parser Opts
 opts = Opts
@@ -26,10 +24,6 @@ opts = Opts
       <> metavar "FILEPATH"
       <> help "Directory the daml.yaml points to your source" )
 
-  where
-    intOption :: Mod OptionFields Int -> Parser Int
-    intOption = option auto
-
 main :: IO ()
 main = do
   options <- execParser $ info (opts <**> helper) $ mconcat
@@ -37,4 +31,7 @@ main = do
     , progDesc "Run cucumber tests in daml script"
     , header "daml-cucumber cli tool"
     ]
-  runTestSuite options
+  runTestSuite
+    (_opts_directory options)
+    (_opts_featureFile options)
+    (_opts_damlSourceDir options)

--- a/hs/src-exe/Main.hs
+++ b/hs/src-exe/Main.hs
@@ -9,6 +9,7 @@ data Opts = Opts
   , _opts_damlSourceDir :: FilePath
   , _opts_allowMissing :: Bool
   , _opts_generateOnly :: Bool
+  , _opts_verbose :: Bool
   }
 
 opts :: Parser Opts
@@ -31,6 +32,9 @@ opts = Opts
   <*> flag False True
       ( long "generate-only"
       <> help "Generate daml test script but don't run the tests" )
+  <*> flag False True
+      ( long "verbose"
+      <> help "Show intermediate output from LSP test run" )
 
 main :: IO ()
 main = do
@@ -45,3 +49,4 @@ main = do
     (_opts_damlSourceDir options)
     (_opts_allowMissing options)
     (_opts_generateOnly options)
+    (_opts_verbose options)

--- a/hs/src/Daml/Cucumber.hs
+++ b/hs/src/Daml/Cucumber.hs
@@ -1,4 +1,6 @@
-module Daml.Cucumber where
+module Daml.Cucumber
+  ( runTestSuite
+  ) where
 
 import Control.Monad.Extra
 import Control.Monad.State (State, modify, runState)
@@ -6,8 +8,6 @@ import Daml.Cucumber.Daml.Parse
 import Daml.Cucumber.LSP
 import Daml.Cucumber.Parse
 import Daml.Cucumber.Types
-import qualified Data.Aeson as Aeson
-import qualified Data.ByteString.Lazy as LBS
 import Data.Foldable
 import Data.Map (Map)
 import qualified Data.Map as Map
@@ -22,15 +22,6 @@ import System.Directory
 import System.FilePath hiding (hasExtension)
 import System.IO
 import Text.Casing
-
-data Opts = Opts
-  { _opts_directory :: FilePath
-  , _opts_featureFile :: Maybe FilePath
-  , _opts_damlSourceDir :: FilePath
-  }
-
-writeFeatureJson :: FilePath -> Feature -> IO ()
-writeFeatureJson path f = LBS.writeFile path (Aeson.encode f)
 
 -- A file like .daml counts as having the extension .daml even though that isn't correct!
 -- thus this function:
@@ -51,8 +42,8 @@ findFilesRecursive pred' dir = do
   others <- mapM (findFilesRecursive pred') directories
   pure $ files <> mconcat others
 
-runTestSuite :: Opts -> IO ()
-runTestSuite (Opts folder mFeatureFile damlFolder) = do
+runTestSuite :: FilePath -> Maybe FilePath -> FilePath -> IO ()
+runTestSuite folder mFeatureFile damlFolder = do
   allFiles <- findFilesRecursive (/= ".daml") folder
   let
     extraPred = case mFeatureFile of

--- a/hs/src/Daml/Cucumber.hs
+++ b/hs/src/Daml/Cucumber.hs
@@ -67,7 +67,6 @@ data Test = Test
   , test_missing :: Set Step
   , test_features :: [Feature]
   }
---   ,
 
 generateTest :: Files -> IO (Either Text Test)
 generateTest f = do

--- a/hs/src/Daml/Cucumber.hs
+++ b/hs/src/Daml/Cucumber.hs
@@ -99,14 +99,15 @@ generateTest f = do
               , test_features = feats
               }
 
-runTestSuite :: FilePath -> Maybe FilePath -> FilePath -> Bool -> Bool -> IO ()
-runTestSuite folder mFeatureFile damlFolder allowMissing generateOnly = do
+runTestSuite :: FilePath -> Maybe FilePath -> FilePath -> Bool -> Bool -> Bool -> IO ()
+runTestSuite folder mFeatureFile damlFolder allowMissing generateOnly verbose = do
   f@(Files featureFiles damlFiles) <- getProjectFiles folder mFeatureFile
-  putStrLn "Found feature files"
-  for_ featureFiles $ putStrLn . ("  " <>)
-  putStrLn ""
-  putStrLn "Found DAML files"
-  for_ damlFiles $ putStrLn . ("  " <>)
+  when verbose $ do
+    putStrLn "Found feature files"
+    for_ featureFiles $ putStrLn . ("  " <>)
+    putStrLn ""
+    putStrLn "Found DAML files"
+    for_ damlFiles $ putStrLn . ("  " <>)
   mscript <- generateTest f
   case mscript of
     Left err -> do
@@ -119,7 +120,7 @@ runTestSuite folder mFeatureFile damlFolder allowMissing generateOnly = do
       case shouldRunTests of
         True -> do
           writeDamlScript testFile result
-          result' <- runTestLspSession folder testFile $ fmap damlFuncName $ damlFunctions result
+          result' <- runTestLspSession folder testFile verbose $ fmap damlFuncName $ damlFunctions result
           case result' of
             Left err -> do
               T.putStrLn $ "lsp session failed: " <> err

--- a/hs/src/Daml/Cucumber.hs
+++ b/hs/src/Daml/Cucumber.hs
@@ -74,8 +74,8 @@ runTestSuite folder mFeatureFile damlFolder allowMissing = do
       writeDamlScript testfile result
       result' <- runTestLspSession folder testfile $ fmap damlFuncName $ damlFunctions result
       case result' of
-        Left error -> do
-          T.putStrLn $ "lsp session failed: " <> error
+        Left err -> do
+          T.putStrLn $ "lsp session failed: " <> err
           exitFailure
 
         Right testResults -> do

--- a/hs/src/Daml/Cucumber/Daml/Parse.hs
+++ b/hs/src/Daml/Cucumber/Daml/Parse.hs
@@ -1,10 +1,13 @@
-module Daml.Cucumber.Daml.Parse where
+module Daml.Cucumber.Daml.Parse
+  ( DamlFile(..)
+  , Definition(..)
+  , parseDamlFile
+  ) where
 
 import Control.Monad
 import Daml.Cucumber.Daml.Parser
 import Daml.Cucumber.Daml.Tokenizer
-import Daml.Cucumber.Types hiding (identifier)
-import Data.Foldable
+import Daml.Cucumber.Types
 import Data.Text (Text)
 import qualified Data.Text as T
 
@@ -33,18 +36,6 @@ data TypeSig
   = Reg Type
   | Func FunctionType
   deriving (Eq, Show)
-
-parser :: Parser [Definition]
-parser = do
-  mDef <- try parseDefinition
-  case mDef of
-    Just def -> (def:) <$> parser
-    Nothing -> do
-      eat
-      ended <- isEof
-      case ended of
-        True -> pure []
-        False -> parser
 
 parseType :: Text -> Parser Type
 parseType name = do
@@ -129,9 +120,3 @@ parseFileDefinitions path = do
 parseDamlFile :: FilePath -> IO (Maybe DamlFile)
 parseDamlFile path =
   fmap (DamlFile path) <$> parseFileDefinitions path
-
-testParseAFile :: FilePath -> IO ()
-testParseAFile path = do
-  results <- parseFile path $ parseAll parseDefinition
-  for_ results (putStrLn . show)
-  pure ()

--- a/hs/src/Daml/Cucumber/Daml/Parser.hs
+++ b/hs/src/Daml/Cucumber/Daml/Parser.hs
@@ -1,4 +1,14 @@
-module Daml.Cucumber.Daml.Parser where
+module Daml.Cucumber.Daml.Parser
+  ( Parser(..)
+  , identifier
+  , expect
+  , peek
+  , eat
+  , try
+  , accept
+  , parseFile
+  , parseAll
+  ) where
 
 import Control.Monad.State
 import Data.Text (Text)

--- a/hs/src/Daml/Cucumber/Daml/Tokenizer.hs
+++ b/hs/src/Daml/Cucumber/Daml/Tokenizer.hs
@@ -1,4 +1,8 @@
-module Daml.Cucumber.Daml.Tokenizer where
+module Daml.Cucumber.Daml.Tokenizer
+  ( Token(..)
+  , tokenize
+  , tokenToText
+  ) where
 
 import Data.Text (Text)
 import qualified Data.Text as T

--- a/hs/src/Daml/Cucumber/LSP.hs
+++ b/hs/src/Daml/Cucumber/LSP.hs
@@ -1,4 +1,6 @@
-module Daml.Cucumber.LSP where
+module Daml.Cucumber.LSP
+  ( runTestLspSession
+  ) where
 
 import Control.Applicative
 import Control.Monad
@@ -46,8 +48,8 @@ getTracesAndErrors :: TestResult -> ([Text], Text)
 getTracesAndErrors (TestResultRan (RanTest traces errors)) = (traces, errors)
 getTracesAndErrors _ = ([], "")
 
-exampleTrace :: Text
-exampleTrace = "Transactions: Active contracts: Return value: {}Trace: \\\"Given a party\\\"  \\\"When the party creates contract X\\\"  \\\"Then Contract X is created\\\""
+_exampleTrace :: Text
+_exampleTrace = "Transactions: Active contracts: Return value: {}Trace: \\\"Given a party\\\"  \\\"When the party creates contract X\\\"  \\\"Then Contract X is created\\\""
 
 parseTraces :: Text -> [Text]
 parseTraces input
@@ -225,6 +227,8 @@ damlIde cwd rpcEvent = do
     sendPipe = fmap (SendPipe_Message . T.encodeUtf8 . makeReq . wrapRequest) rpcEvent
 
   process <- createProcess damlProc (ProcessConfig sendPipe never)
+  performEvent_ $ ffor (_process_stdout process) $ liftIO . print
+  performEvent_ $ ffor (_process_stderr process) $ liftIO . print
 
   let
     stdout = _process_stdout process

--- a/hs/src/Daml/Cucumber/Parse.hs
+++ b/hs/src/Daml/Cucumber/Parse.hs
@@ -1,4 +1,6 @@
-module Daml.Cucumber.Parse where
+module Daml.Cucumber.Parse
+  ( parseFeature
+  ) where
 
 import Daml.Cucumber.Types
 import qualified Language.Abacate as A

--- a/hs/src/Daml/Cucumber/Types.hs
+++ b/hs/src/Daml/Cucumber/Types.hs
@@ -1,4 +1,11 @@
-module Daml.Cucumber.Types where
+module Daml.Cucumber.Types
+  ( Feature(..)
+  , Step(..)
+  , Examples(..)
+  , Outline(..)
+  , Scenario(..)
+  , Keyword(..)
+  ) where
 
 import Data.Aeson
 import Data.Text (Text)


### PR DESCRIPTION
Make it possible to generate the daml test script without running the tests

Also adds some error reporting for parse failures