### PR TITLE
Allow user specified state in Cucumber monad, report compile errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,22 +32,36 @@ Feature: Example
 You can implement each step as a `Cucumber` action. As long as you annotate the step with a comment that matches the step definition in your feature file, it will be detected and run at the appropriate time.
 
 ```haskell
+data Ctx = Ctx with
+  party1 : Optional Party
+
+instance Default Ctx where
+  def = Ctx with party1 = None
+
 -- Given a party
-givenAParty: Cucumber Party
-givenAParty = liftScript $ allocateParty "alice"
+givenAParty: Cucumber Ctx ()
+givenAParty = do
+  p <- liftScript $ allocateParty "alice"
+  set $ Ctx with party1 = p
 
 -- When the party creates contract X
-whenThePartyCreatesContact : Cucumber (ContractId X)
-whenThePartyCreatesContact = liftScript $ do
-  [alice] <- listKnownParties
-  submit alice.party $ createCmd X with owner = alice.party
+whenThePartyCreatesContact : Cucumber Ctx ()
+whenThePartyCreatesContact = do
+  malice <- gets party1
+  case malice of
+    Some alice -> liftScript $ submit alice $ createCmd X with owner = alice
+    _ -> error "Missing party1"
 
 -- Then Contract X is created
-thenContractIsCreated : Cucumber ()
-thenContractIsCreated = liftScript $ do
-  [alice] <- listKnownParties
-  contracts <- query @X alice.party
-  assertMsg "Must have exactly one contract" $ Prelude.length contracts == 1
+thenContractIsCreated : Cucumber Ctx ()
+thenContractIsCreated = do
+  malice <- gets party1
+  case malice of
+    Some alice -> do
+      contracts <- query @X alice
+      assertMsg "Must have exactly one contract" $ Prelude.length contracts == 1
+    _ -> error "Missing party1"
+
 ```
 
 ### daml-cucumber executable

--- a/daml/Cucumber.daml
+++ b/daml/Cucumber.daml
@@ -14,105 +14,21 @@ module Cucumber
   , module StateT
   ) where
 
-import DA.Action
 import DA.Action.State.Class
-import DA.Set
 import Daml.Script
 import LiftScript
 import StateT
+import Default
 
-data StepKey = StepKey
-  { keyword : Keyword
-  , identifier : Text
+newtype Cucumber s a = Cucumber
+  { unCucumber : StateT s Script a
   }
-  deriving (Eq, Show, Ord)
+ deriving (Functor, Applicative, Action, ActionState s)
 
-data Message
-  = StepComplete StepKey
-  | ScenarioComplete Text
-  | DuplicateStepFound StepKey
-  | DuplicateScenarioFound Text
-
-data Keyword = Given | When | Then | And | But
-  deriving (Eq, Show, Enum, Bounded, Ord)
-
-data StepResult = StepResult
-  with
-    stepKeyword : Keyword
-    ident : Text
-    success : Bool
-
-data Context = Context
-  { currentScenario : Optional Text
-  , currentStep : Optional StepKey
-  , scenarioRecords : Set Text
-  , stepRecords : Set StepKey
-  , results : [Message]
-  }
-
-newtype Cucumber a = Cucumber
-  { unCucumber : StateT Context Script a
-  }
- deriving (Functor, Applicative, Action, ActionState Context)
-
-instance LiftScript Cucumber where
+instance LiftScript (Cucumber s) where
   liftScript action = Cucumber (liftScript action)
 
-startingContext: Context
-startingContext = Context None None mempty mempty mempty
-
-runCucumber : Cucumber a -> Script (a, Context)
-runCucumber testAction =
-  runState startingContext action
-  where
-    Cucumber action = do
-      result <- testAction
-      tryRecordStep
-      tryRecordScenario
-      pure result
-
-report : Message -> Cucumber ()
-report msg =
-  modify $ \c -> c { results = c.results <> [msg] }
-
-tryRecordScenario : Cucumber ()
-tryRecordScenario = do
-  -- Record the results of the current scenario
-  records <- gets scenarioRecords
-  scenario <- gets currentScenario
-  case scenario of
-    Some name -> do
-      when (member name records) $ report $ DuplicateScenarioFound name
-      report $ ScenarioComplete name
-      modify (\c -> c { scenarioRecords = insert name c.scenarioRecords
-                      , currentScenario = None
-                      })
-    _ -> pure ()
-
-tryRecordStep : Cucumber ()
-tryRecordStep = do
-  -- Record the results of the current step
-  records <- gets stepRecords
-  step <- gets currentStep
-  case step of
-    Some key -> do
-      when (member key records) $ report $ DuplicateStepFound key
-      report $ StepComplete key
-      modify (\c -> c { stepRecords = insert key c.stepRecords
-                      , currentStep = None
-                      })
-    _ -> pure ()
-
--- TODO remove the conflict in this name with Prelude.scenario
-scenario' : Text -> Cucumber ()
-scenario' name = do
-  tryRecordStep
-  tryRecordScenario
-  -- 'Push' on the current step
-  modify (\c -> c { currentScenario = Some name })
-
-step : Keyword -> Text -> Cucumber ()
-step keyword ident = do
-  tryRecordStep
-  -- 'Push' on the current step
-  modify (\c -> c { currentStep = Some (StepKey keyword ident) })
+runCucumber : Default s => Cucumber s a -> Script a
+runCucumber (Cucumber testAction) = do
+  (a, _) <- runState def testAction
+  pure a

--- a/daml/Default.daml
+++ b/daml/Default.daml
@@ -1,0 +1,16 @@
+{-|
+Module      : Default
+Description : Default values for types
+Copyright   : (c) Obsidian Systems LLC, 2024
+License     : BSD-3-Clause
+Maintainer  : maintainer@obsidian.systems
+
+Allows the specification of a default for a type
+-}
+module Default where
+
+class Default a where
+  def: a
+
+instance Default () where
+  def = ()

--- a/default.nix
+++ b/default.nix
@@ -35,8 +35,7 @@ let
         buildPhase = ''
           cp ${damlLib}/dist.dar test/dist.dar
           substituteInPlace test/daml.yaml \
-            --replace "2.6.5" ${version} \
-            --replace "../daml/.daml/dist/daml-cucumber-0.1.0.0.dar" dist.dar
+            --replace "2.6.5" ${version}
           ${hsBuild.daml-cucumber}/bin/daml-cucumber --generate-only --source ./test --features ./test/features.feature
           cd test && ${damlSdk.sdk}/bin/daml test > test-result
         '';

--- a/hs/daml-cucumber.cabal
+++ b/hs/daml-cucumber.cabal
@@ -22,6 +22,7 @@ library
   import:             warnings
   exposed-modules:
     Daml.Cucumber
+    Daml.Cucumber.Utils
     Daml.Cucumber.Daml.Parse
     Daml.Cucumber.Daml.Parser
     Daml.Cucumber.Daml.Tokenizer

--- a/hs/src/Daml/Cucumber/Daml/Parse.hs
+++ b/hs/src/Daml/Cucumber/Daml/Parse.hs
@@ -1,6 +1,8 @@
 module Daml.Cucumber.Daml.Parse
   ( DamlFile(..)
   , Definition(..)
+  , Type(..)
+  , TypeSig(..)
   , parseDamlFile
   ) where
 
@@ -30,7 +32,7 @@ data FunctionType = FunctionType
   deriving (Eq, Show)
 
 data Type = Type Text [Text]
-  deriving (Eq, Show)
+  deriving (Eq, Ord, Show)
 
 data TypeSig
   = Reg Type

--- a/hs/src/Daml/Cucumber/LSP.hs
+++ b/hs/src/Daml/Cucumber/LSP.hs
@@ -2,6 +2,7 @@ module Daml.Cucumber.LSP
   ( runTestLspSession
   ) where
 
+import Daml.Cucumber.Utils
 import Control.Applicative
 import Control.Monad
 import Control.Monad.Fix
@@ -43,6 +44,10 @@ data TestResult
   = TestResultRan RanTest
   | TestResultDoesn'tCompile Text
   deriving (Eq, Ord, Show)
+
+getCompileError :: TestResult -> Maybe Text
+getCompileError (TestResultDoesn'tCompile reason) = Just reason
+getCompileError _ = Nothing
 
 getTracesAndErrors :: TestResult -> ([Text], Text)
 getTracesAndErrors (TestResultRan (RanTest traces errors)) = (traces, errors)
@@ -94,7 +99,7 @@ instance FromJSON TestResponse where
         T.drop 1 . T.dropWhile (/= '=') . T.dropWhile (/= '&') <$> params .: "uri"
 
       extractData = innerText . dropWhile (~/= (TagOpen "div" [("class", "da-code transaction")] :: Tag Text))
-      extractNoteData = innerText . dropWhile (~/= (TagOpen "div" [("class", "da-hl-warning")] :: Tag Text))
+      extractNoteData = innerText . dropWhile (~/= (TagOpen "span" [("class", "da-hl-warning")] :: Tag Text))
 
 getRPC :: Response -> Maybe (RPC Value)
 getRPC (Notification rpc) = Just rpc
@@ -148,14 +153,13 @@ runTestLspSession cwd filepath verbose testNames = do
           True -> Just a
           False -> Nothing
 
-    pure $ leftmost [ fmap Right $ bounce ((== length reqs) . length) $ updated $ Set.toList <$> currentResults
+      newResults = updated $ Set.toList <$> currentResults
+
+    pure $ leftmost [ fmap Right $ bounce ((== length reqs) . length) $ newResults
+                    , fmap (Left . ("Daml doesn't compile (are you missing a Default instance for your context type?):\n" <>)) $  bounce (not . T.null) $ (T.intercalate "\n" . catMaybes . fmap (getCompileError . testResponseResult)) <$> newResults
                     , Left <$> failed
                     ]
   pure $ fmap (mconcat . fmap (\(TestResponse name result) -> Map.singleton name $ getTracesAndErrors result)) testResults
-
-safeHead :: [a] -> Maybe a
-safeHead (a:_) = Just a
-safeHead _ = Nothing
 
 tShow :: Show a => a -> Text
 tShow = T.pack . show

--- a/hs/src/Daml/Cucumber/Utils.hs
+++ b/hs/src/Daml/Cucumber/Utils.hs
@@ -1,0 +1,5 @@
+module Daml.Cucumber.Utils (safeHead) where
+
+safeHead :: [a] -> Maybe a
+safeHead (a:_) = Just a
+safeHead _ = Nothing

--- a/test/daml/Default.daml
+++ b/test/daml/Default.daml
@@ -1,0 +1,1 @@
+../../daml/Default.daml

--- a/test/daml/Test.daml
+++ b/test/daml/Test.daml
@@ -1,13 +1,15 @@
 module Test where
 
 import Cucumber
+import DA.Action.State.Class
 import DA.Foldable
 import Daml.Script
-import Default
 
-data BasicContext = BasicContext
+data BasicContext = BasicContext with
+  party1 : Optional Party
+
 instance Default BasicContext where
-  def = BasicContext
+  def = BasicContext None
 
 template X
   with
@@ -103,20 +105,26 @@ givenThisOtherGuyIKnow : Cucumber BasicContext ()
 givenThisOtherGuyIKnow = pure ()
 
 -- Given a party
-givenAParty: Cucumber BasicContext Party
-givenAParty = liftScript $ allocateParty "alice"
+givenAParty: Cucumber BasicContext ()
+givenAParty = do
+  p <- liftScript $ allocateParty "alice"
+  put $ BasicContext (Some p)
+
+withParty1 f = do
+  malice <- gets party1
+  case malice of
+    Some alice -> f alice
+    _ -> error "Missing party1"
 
 -- When the party creates contract X
 whenThePartyCreatesContact : Cucumber BasicContext (ContractId X)
-whenThePartyCreatesContact = liftScript $ do
-  [alice] <- listKnownParties
-  submit alice.party $ createCmd X with owner = alice.party
+whenThePartyCreatesContact = withParty1 $ \alice ->
+  liftScript $ submit alice $ createCmd X with owner = alice
 
 -- Then Contract X is created
 thenContractIsCreated : Cucumber BasicContext ()
-thenContractIsCreated = liftScript $ do
-  [alice] <- listKnownParties
-  contracts <- query @X alice.party
+thenContractIsCreated = withParty1 $ \alice -> liftScript $ do
+  contracts <- query @X alice
   assertMsg "Must have exactly one contract" $ Prelude.length contracts == 1
 
 -- Then he also did something

--- a/test/daml/Test.daml
+++ b/test/daml/Test.daml
@@ -1,16 +1,13 @@
 module Test where
 
 import Cucumber
-import DA.Action
-import DA.Action.State.Class
-import DA.Either
-import DA.Exception
 import DA.Foldable
-import DA.Optional
-import DA.Set
-import DA.Stack
 import Daml.Script
-import StateT
+import Default
+
+data BasicContext = BasicContext
+instance Default BasicContext where
+  def = BasicContext
 
 template X
   with
@@ -18,36 +15,24 @@ template X
   where
     signatory owner
 
-main : Script [Message]
+main : Script ()
 main = do
-  (_, ctx) <- runCucumber allTests
-  pure ctx.results
+  runCucumber allTests
 
-allTests: Cucumber ()
+allTests: Cucumber BasicContext ()
 allTests = do
   testStepsCanOnlyBeDefinedOnce
   testMultipleScenariosInOneTest
   testScenarioOutlineByJustEnumerating
 
-testStepsCanOnlyBeDefinedOnce: Cucumber ()
+testStepsCanOnlyBeDefinedOnce: Cucumber BasicContext ()
 testStepsCanOnlyBeDefinedOnce = do
-  step Given "a party"
   liftScript $ allocateParty "alice"
-  step Given "a party"
-  step When "the party creates contract X"
   parties <- liftScript listKnownParties
-  step Then "Contract X is created"
+  pure ()
 
-testMultipleScenariosInOneTest: Cucumber ()
+testMultipleScenariosInOneTest: Cucumber BasicContext ()
 testMultipleScenariosInOneTest = do
-  scenario' "A something that can be tested"
-   -- ^ Note you can optionally define the Scenario if you wanna, though you don't have to
-  step Given "a guy does a thing"
-  step Then "well he did a thing"
-
-  scenario' "Something else that can be tested"
-  step Given "this other guy I know"
-  step Then "he also did something"
   pure ()
 
 data AnimalCategory
@@ -81,79 +66,77 @@ instance Show AnimalType where
     NotToaster -> "toaster"
 
 -- Given there is a animal and a type
-a: Cucumber ()
+a: Cucumber BasicContext ()
 a = do
   pure ()
 
 -- Then the Dog is pretty cool I guess
-b: Cucumber ()
+b: Cucumber BasicContext ()
 b = do
   pure ()
 
 -- And the Cat is a toaster
-c: Cucumber ()
+c: Cucumber BasicContext ()
 c = do
   pure ()
 
 -- And the Dog is a mammal
-d: Cucumber ()
+d: Cucumber BasicContext ()
 d = do
   pure ()
 
 -- Given a guy does a thing
-testScenarioOutlineByJustEnumerating: Cucumber ()
+testScenarioOutlineByJustEnumerating: Cucumber BasicContext ()
 testScenarioOutlineByJustEnumerating = do
-  step Given "there is a animal and a animal type"
   forA_ categories $ \category -> do
     forA_ types $ \t ->  testSingleCase category t
-    step Then $ "the " <> show category <> " is pretty cool I guess"
   where
     categories = [minBound .. maxBound]
     types = [minBound .. maxBound]
 
 -- Given there is a document and a type
-givenAAnimalType : Cucumber ()
+givenAAnimalType : Cucumber BasicContext ()
 givenAAnimalType = pure ()
 
 -- Given this other guy I know
-givenThisOtherGuyIKnow : Cucumber ()
+givenThisOtherGuyIKnow : Cucumber BasicContext ()
 givenThisOtherGuyIKnow = pure ()
 
 -- Given a party
-givenAParty: Cucumber Party
+givenAParty: Cucumber BasicContext Party
 givenAParty = liftScript $ allocateParty "alice"
 
 -- When the party creates contract X
-whenThePartyCreatesContact : Cucumber (ContractId X)
+whenThePartyCreatesContact : Cucumber BasicContext (ContractId X)
 whenThePartyCreatesContact = liftScript $ do
   [alice] <- listKnownParties
   submit alice.party $ createCmd X with owner = alice.party
 
 -- Then Contract X is created
-thenContractIsCreated : Cucumber ()
+thenContractIsCreated : Cucumber BasicContext ()
 thenContractIsCreated = liftScript $ do
   [alice] <- listKnownParties
   contracts <- query @X alice.party
   assertMsg "Must have exactly one contract" $ Prelude.length contracts == 1
 
 -- Then he also did something
-thenHeAlsoDidSomething : Cucumber ()
+thenHeAlsoDidSomething : Cucumber BasicContext ()
 thenHeAlsoDidSomething = pure ()
 
 -- Then the Dog Mammal is pretty cool I guess
-thenTheDogMammalIsCool : Cucumber ()
+thenTheDogMammalIsCool : Cucumber BasicContext ()
 thenTheDogMammalIsCool = pure ()
 
 -- Then the Cat is pretty cool I guess
-thenWait : Cucumber ()
+thenWait : Cucumber BasicContext ()
 thenWait = pure ()
 
 -- Then this isn't implemented
-thenNotImplemented : Cucumber ()
+thenNotImplemented : Cucumber BasicContext ()
 thenNotImplemented = pure ()
 
 -- Then well he did a thing
-thenWellHeDidAThing : Cucumber ()
+thenWellHeDidAThing : Cucumber BasicContext ()
 thenWellHeDidAThing = do
   liftScript $ do
     allocatePartyWithHint "X" (PartyIdHint "X")
@@ -161,13 +144,13 @@ thenWellHeDidAThing = do
   pure ()
 
 -- And the Parrot is a Salad
-andTheIden : Cucumber ()
+andTheIden : Cucumber BasicContext ()
 andTheIden = pure ()
 
 -- And the Cat is a Bird
-isPdf : Cucumber ()
+isPdf : Cucumber BasicContext ()
 isPdf = pure ()
 
-testSingleCase: AnimalCategory -> AnimalType -> Cucumber ()
+testSingleCase: AnimalCategory -> AnimalType -> Cucumber BasicContext ()
 testSingleCase dc dt = do
-  step And $ "the " <> show dc <> " is a " <> show dt
+  pure ()


### PR DESCRIPTION
The Cucumber type now allows users to specify the type that will be used as state, this type must have a Default instance.

If multiple actions exist that take different types for state that is reported as an error and all the locations of different types are mentioned in the output.