### PR TITLE
Tweak error message formatting to handle long strings produced by DA.…

### DIFF
--- a/hs/src/Daml/Cucumber.hs
+++ b/hs/src/Daml/Cucumber.hs
@@ -348,7 +348,6 @@ writeDamlScript path state = liftIO $ do
   T.hPutStrLn handle $ "module " <> moduleName <> " where"
 
   T.hPutStrLn handle "import Cucumber"
-  T.hPutStrLn handle "import StateT"
   T.hPutStrLn handle "import Daml.Script"
 
   for_ (Set.toList $ damlImports state) $ \theImport -> do

--- a/hs/src/Daml/Cucumber.hs
+++ b/hs/src/Daml/Cucumber.hs
@@ -284,6 +284,7 @@ formatError = layoutSmart
   . reflow
   . T.unwords
   . T.words
+  . T.replace ":" ": "
 
 collateStepResults :: [Text] -> [(Text, Bool)]
 collateStepResults (name:"pass": rest) = (name, True) : collateStepResults rest


### PR DESCRIPTION
…Exception

E.g. DA.Exception.GeneralError:GeneralError@86828b9843465f419db1ef8a8ee741d1eef645df02375ebf509cdc8c3ddd16cb