### PR TITLE
Allow Cucumber state in type synonyms, fake false flagging in multiline comments

### DIFF
--- a/hs/daml-cucumber.cabal
+++ b/hs/daml-cucumber.cabal
@@ -38,6 +38,7 @@ library
     , aeson                  >=2.1.1   && <2.2
     , ansi-terminal          >=0.11    && <1.1
     , base                   >=4.14    && <5
+    , lens                   >=5       && <6
     , bytestring             >=0.10.12 && <0.11
     , casing                 >=0.1.4   && <0.2
     , containers             >=0.6.5   && <0.7

--- a/hs/src/Daml/Cucumber/Daml/Parser.hs
+++ b/hs/src/Daml/Cucumber/Daml/Parser.hs
@@ -10,6 +10,7 @@ module Daml.Cucumber.Daml.Parser
   , parseAll
   ) where
 
+import Control.Applicative
 import Control.Monad.State
 import Data.Text (Text)
 import qualified Data.Text.IO as T
@@ -19,7 +20,7 @@ import Daml.Cucumber.Daml.Tokenizer
 newtype Parser a = Parser
   { unParser :: StateT [Token] Maybe a
   }
-  deriving (Functor, Applicative, Monad, MonadFail, MonadState [Token])
+  deriving (Functor, Applicative, Monad, MonadFail, MonadState [Token], Alternative)
 
 runParser :: [Token] -> Parser a -> Maybe (a, [Token])
 runParser tokens (Parser action) = runStateT action tokens

--- a/test/daml/Test.daml
+++ b/test/daml/Test.daml
@@ -67,13 +67,15 @@ instance Show AnimalType where
     Bird -> "bird"
     NotToaster -> "toaster"
 
+type Test a = Cucumber BasicContext a
+
 -- Given there is a animal and a type
-a: Cucumber BasicContext ()
+a: Test ()
 a = do
   pure ()
 
 -- Then the Dog is pretty cool I guess
-b: Cucumber BasicContext ()
+b: Test ()
 b = do
   pure ()
 


### PR DESCRIPTION
This adds the ability to type synonym the Cucumber monad and have generation work like normal.

Improves parsing support for comments and multiline comments: This prevents things like definitions getting incorrectly parsed from avoiding false flagging of incorrect contexts for example.