### PR TITLE
Generalises state monad transformer and typeclasses

### DIFF
--- a/daml/Cucumber.daml
+++ b/daml/Cucumber.daml
@@ -27,9 +27,7 @@ newtype Cucumber s a = Cucumber
  deriving (Functor, Applicative, Action, ActionState s, ActionFail, CanAssert)
 
 instance LiftScript (Cucumber s) where
-  liftScript action = Cucumber (liftScript action)
+  liftScript = Cucumber . liftScript
 
 runCucumber : Default s => Cucumber s a -> Script a
-runCucumber (Cucumber testAction) = do
-  (a, _) <- runState def testAction
-  pure a
+runCucumber = fmap fst . runState def . unCucumber

--- a/daml/LiftScript.daml
+++ b/daml/LiftScript.daml
@@ -16,9 +16,7 @@ class LiftScript m where
   liftScript : Script a -> m a
 
 instance LiftScript Script where
-  liftScript action = action
+  liftScript = identity
 
-instance (Applicative m, LiftScript m, Action m) => LiftScript (StateT s m) where
-  liftScript action = StateT $ \s -> do
-    a <- liftScript action
-    pure (a, s)
+instance (Applicative m, LiftScript m) => LiftScript (StateT s m) where
+  liftScript action = StateT $ liftA2 (,) (liftScript action) . pure

--- a/daml/StateT.daml
+++ b/daml/StateT.daml
@@ -10,47 +10,47 @@ State monads, passing an updatable state through a computation.
 module StateT where
 
 import DA.Action.State.Class
+import DA.Functor (($>))
+import DA.Tuple (dupe, first)
 
 data StateT s m a = StateT
   { runStateT : s -> m (a, s) }
 
-instance (Applicative m, Action m) => Functor (StateT s m) where
- fmap f (StateT runState) = StateT $ (\s -> do
-   (a, s) <- runState s
-   pure (f a, s))
+instance Functor m => Functor (StateT s m) where
+  fmap f (StateT runState) = StateT $ fmap (first f) . runState
 
-instance (Applicative m, Action m) => Applicative (StateT s m) where
- pure a = StateT $ \s -> pure (a, s)
+instance Action m => Applicative (StateT s m) where
+  pure a = StateT $ pure . (a, )
 
- StateT mf <*> StateT mx = StateT $ \ s -> do
-  (f, s') <- mf s
-  (x, s'') <- mx s'
-  pure (f x, s'')
+  StateT mf <*> StateT mx = StateT $ \s -> do
+    (f, s') <- mf s
+    (x, s'') <- mx s'
+    pure (f x, s'')
 
-instance (Applicative m, Action m) => Action (StateT s m) where
-  m >>= k  = StateT $ \ s -> do
+instance Action m => Action (StateT s m) where
+  m >>= k  = StateT $ \s -> do
     (a, s') <- runStateT m s
     runStateT (k a) s'
 
 instance ActionFail m => ActionFail (StateT s m) where
-  fail m = StateT $ \s -> fail m >> pure (undefined, s)
+  fail m = StateT $ \s -> fail m $> (undefined, s)
 
 instance CanAssert m => CanAssert (StateT s m) where
-  assertFail m = StateT $ \s -> assertFail m >> pure (undefined, s)
+  assertFail m = StateT $ \s -> assertFail m $> (undefined, s)
 
 state
-  : (Action m)
+  : Applicative m
   => (s -> (a, s))  -- ^pure state transformer
   -> StateT s m a   -- ^equivalent state-passing computation
-state f = StateT (pure . f)
+state = StateT . (pure .)
 
-instance Action m => ActionState s (StateT s m) where
-  get = state $ \ s -> (s, s)
-  put s = state $ \ _ -> ((), s)
-  modify f = state $ \ s -> ((), f s)
+instance Applicative m => ActionState s (StateT s m) where
+  get = state dupe
+  put = state . const . ((), )
+  modify = state . (((), ) .)
 
-gets : (Applicative m, ActionState s m) => (s -> a) -> m a
-gets f = f <$> get
+gets : (Functor m, ActionState s m) => (s -> a) -> m a
+gets = (<$> get)
 
 runState: s -> StateT s m a -> m (a, s)
-runState s (StateT f) = f s
+runState = flip runStateT


### PR DESCRIPTION
- Relax typeclass constraints on `StateT` and `LiftScript`
- Refactor `Cucumber`, `LiftScript` and `StateT`