### PR TITLE
Add common typeclass instances

### DIFF
--- a/daml/Cucumber.daml
+++ b/daml/Cucumber.daml
@@ -1,8 +1,6 @@
-{-# LANGUAGE UndecidableInstances #-}
 {-|
 Module      : Cucumber
 Description : Cucumber testing for daml
-
 Copyright   : (c) Obsidian Systems LLC, 2024
 License     : BSD-3-Clause
 Maintainer  : maintainer@obsidian.systems
@@ -10,7 +8,6 @@ Maintainer  : maintainer@obsidian.systems
 Support library for daml-cucumber. Use this library to implement
 cucumber/gherkin steps in daml, and use the daml-cucumber tool to run them.
 -}
-
 module Cucumber
   ( module Cucumber
   , module LiftScript

--- a/daml/Cucumber.daml
+++ b/daml/Cucumber.daml
@@ -34,10 +34,10 @@ newtype Cucumber s a = Cucumber
   Action,
   ActionState s,
   ActionFail,
-  CanAssert,
-  CanAbort,
+  ActionThrow,
   ActionCatch,
-  ActionThrow)
+  CanAssert,
+  CanAbort)
 
 instance LiftScript (Cucumber s) where
   liftScript = Cucumber . liftScript

--- a/daml/Cucumber.daml
+++ b/daml/Cucumber.daml
@@ -1,6 +1,8 @@
+{-# LANGUAGE UndecidableInstances #-}
 {-|
 Module      : Cucumber
 Description : Cucumber testing for daml
+
 Copyright   : (c) Obsidian Systems LLC, 2024
 License     : BSD-3-Clause
 Maintainer  : maintainer@obsidian.systems
@@ -8,6 +10,7 @@ Maintainer  : maintainer@obsidian.systems
 Support library for daml-cucumber. Use this library to implement
 cucumber/gherkin steps in daml, and use the daml-cucumber tool to run them.
 -}
+
 module Cucumber
   ( module Cucumber
   , module LiftScript
@@ -16,6 +19,7 @@ module Cucumber
   ) where
 
 import DA.Action.State.Class
+import DA.Exception
 import Daml.Script
 import Default
 import LiftScript
@@ -24,10 +28,22 @@ import StateT
 newtype Cucumber s a = Cucumber
   { unCucumber : StateT s Script a
   }
- deriving (Functor, Applicative, Action, ActionState s, ActionFail, CanAssert)
+ deriving (
+  Functor,
+  Applicative,
+  Action,
+  ActionState s,
+  ActionFail,
+  CanAssert,
+  CanAbort,
+  ActionCatch,
+  ActionThrow)
 
 instance LiftScript (Cucumber s) where
   liftScript = Cucumber . liftScript
+
+instance HasTime (Cucumber s) where
+  getTime = liftScript getTime
 
 runCucumber : Default s => Cucumber s a -> Script a
 runCucumber = fmap fst . runState def . unCucumber

--- a/daml/StateT.daml
+++ b/daml/StateT.daml
@@ -11,7 +11,6 @@ module StateT where
 
 import DA.Action.State.Class
 import DA.Exception
-import DA.Functor (($>))
 import DA.Tuple (dupe, first)
 
 data StateT s m a = StateT
@@ -34,19 +33,19 @@ instance Action m => Action (StateT s m) where
     runStateT (k a) s'
 
 instance ActionFail m => ActionFail (StateT s m) where
-  fail m = StateT $ (fail m $>) . (undefined, )
+  fail m = StateT $ const (fail m)
 
 instance ActionThrow m => ActionThrow (StateT s m) where
-  throw e = StateT $ (throw e $>) . (undefined, )
+  throw e = StateT $ const (throw e)
 
 instance ActionCatch m => ActionCatch (StateT s m) where
   _tryCatch f g = StateT $ \s -> _tryCatch ((`runStateT` s) . f) (fmap (`runStateT` s) . g)
 
 instance CanAssert m => CanAssert (StateT s m) where
-  assertFail m = StateT $ (assertFail m $>) . (undefined, )
+  assertFail m = StateT $ const (assertFail m)
 
 instance CanAbort m => CanAbort (StateT s m) where
-  abort t = StateT $ (abort t $>) . (undefined, )
+  abort t = StateT $ const (abort t)
 
 state
   : Applicative m

--- a/daml/StateT.daml
+++ b/daml/StateT.daml
@@ -10,6 +10,7 @@ State monads, passing an updatable state through a computation.
 module StateT where
 
 import DA.Action.State.Class
+import DA.Exception
 import DA.Functor (($>))
 import DA.Tuple (dupe, first)
 
@@ -33,10 +34,19 @@ instance Action m => Action (StateT s m) where
     runStateT (k a) s'
 
 instance ActionFail m => ActionFail (StateT s m) where
-  fail m = StateT $ \s -> fail m $> (undefined, s)
+  fail m = StateT $ (fail m $>) . (undefined, )
+
+instance ActionThrow m => ActionThrow (StateT s m) where
+  throw e = StateT $ (throw e $>) . (undefined, )
+
+instance ActionCatch m => ActionCatch (StateT s m) where
+  _tryCatch f g = StateT $ \s -> _tryCatch ((`runStateT` s) . f) (fmap (`runStateT` s) . g)
 
 instance CanAssert m => CanAssert (StateT s m) where
-  assertFail m = StateT $ \s -> assertFail m $> (undefined, s)
+  assertFail m = StateT $ (assertFail m $>) . (undefined, )
+
+instance CanAbort m => CanAbort (StateT s m) where
+  abort t = StateT $ (abort t $>) . (undefined, )
 
 state
   : Applicative m

--- a/daml/StateT.daml
+++ b/daml/StateT.daml
@@ -33,19 +33,19 @@ instance Action m => Action (StateT s m) where
     runStateT (k a) s'
 
 instance ActionFail m => ActionFail (StateT s m) where
-  fail m = StateT $ const (fail m)
+  fail = StateT . const . fail 
 
 instance ActionThrow m => ActionThrow (StateT s m) where
-  throw e = StateT $ const (throw e)
+  throw = StateT . const . throw
 
 instance ActionCatch m => ActionCatch (StateT s m) where
   _tryCatch f g = StateT $ \s -> _tryCatch ((`runStateT` s) . f) (fmap (`runStateT` s) . g)
 
 instance CanAssert m => CanAssert (StateT s m) where
-  assertFail m = StateT $ const (assertFail m)
+  assertFail = StateT . const . assertFail
 
 instance CanAbort m => CanAbort (StateT s m) where
-  abort t = StateT $ const (abort t)
+  abort = StateT . const . abort
 
 state
   : Applicative m


### PR DESCRIPTION
- Add `ActionThrow`, `ActionCatch`, `CanAbort` and `HasTime` in appropriate data types
- Fix existing implementation of some typeclass instances where error messages become `Not implemented` due to the use of `undefined`